### PR TITLE
Remove /video-tutorials link from header

### DIFF
--- a/lib/header/demo.jade
+++ b/lib/header/demo.jade
@@ -40,8 +40,6 @@ header.site-header
                   li
                     a(href='/resources') Resources
                   li
-                    a(href='/video-tutorials') Video Tutorials
-                  li
                     a(href='/partners') Partners
                   li
                     a(href='/opensource') Open Source


### PR DESCRIPTION
https://auth0.com/video-tutorials was removed https://github.com/auth0/auth0-website/pull/573