### PR TITLE
Remove Sales label from main phone numbers

### DIFF
--- a/lib/footer/demo.jade
+++ b/lib/footer/demo.jade
@@ -67,11 +67,10 @@ footer.site-footer
             | Suite 700
             br
             | Bellevue, WA   98004
-            a(href="tel:+18882352699") +1 (888) 235-2699
 
         .column.no-heading
-          .item.item-phone-label Sales
           .item
+            a(href="tel:+18882352699") +1 (888) 235-2699
             a(href="tel:+14253126521") +1 (425) 312-6521
           .item.item-phone-label Support
           .item

--- a/lib/footer/index.styl
+++ b/lib/footer/index.styl
@@ -106,13 +106,13 @@ footer.site-footer
 
     .no-heading
       text-align: right;
+      padding-top: 37px;
       position: absolute;
       right: 0;
       top: 18px;
 
       +breakpoint("desktop")
         position: static;
-        padding-top: 7px;
 
       .item
         font-size: 12px;


### PR DESCRIPTION
Remove Sales label from main phone numbers. Sales phone number aren't sales specific numbers, they are main (general) phone numbers. Thanks @vctrfrnndz for the design help!

<img width="1006" alt="screen shot 2016-06-06 at 4 44 35 pm" src="https://cloud.githubusercontent.com/assets/7464663/15835363/06e1bf84-2c06-11e6-9208-58be4470e919.png">
