### PR TITLE
Fix scroll of modals on Safari iOS

### DIFF
--- a/lib/modals/index.styl
+++ b/lib/modals/index.styl
@@ -34,9 +34,13 @@ $modal-sm ?=                  300px
 // .modal-dialog - positioning shell for the actual modal
 // .modal-content - actual modal w/ bg and corners and shit
 
-// Kill the scroll on the body
+// Kill the scroll on the body, also on Safari iOS
+// More: From http://stackoverflow.com/a/32698531
 .modal-open
+  height 100%
   overflow hidden
+  position fixed
+  width 100%
 
 // Container that the modal scrolls within
 .modal


### PR DESCRIPTION
Actually Safari iOS ignores `overflow: hidden;` on body and html tags. Solution found in http://stackoverflow.com/a/32698531