### PR TITLE
Update engines in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "auth0-styleguide",
   "version": "4.8.8",
   "engines": {
-    "node": "4.3.2"
+    "node": "^4.4.7"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
To avoid warnings like:

```
npm WARN engine auth0-styleguide@4.8.5: wanted: {"node":"4.3.2"} (current: {"node":"4.4.7","npm":"2.15.8"})
```