### PR TITLE
Remove .modal-open fix for iOS Safari

### DIFF
--- a/lib/modals/index.styl
+++ b/lib/modals/index.styl
@@ -34,13 +34,8 @@ $modal-sm ?=                  300px
 // .modal-dialog - positioning shell for the actual modal
 // .modal-content - actual modal w/ bg and corners and shit
 
-// Kill the scroll on the body, also on Safari iOS
-// More: From http://stackoverflow.com/a/32698531
 .modal-open
-  height 100%
   overflow hidden
-  position fixed
-  width 100%
 
 // Container that the modal scrolls within
 .modal


### PR DESCRIPTION
Because it makes the scroll go to the top on all browser and devices. This will allow the scroll on iOS Safari with a modal open. Deal.

See the previous bug fix: https://github.com/auth0/styleguide/pull/80