### PR TITLE
Fix undefined variables (Fix #95)

### DIFF
--- a/lib/code/index.styl
+++ b/lib/code/index.styl
@@ -67,7 +67,7 @@ pre
     color inherit
     white-space pre-wrap
     background-color transparent
-    border-radius $border-radius
+    border-radius $border-radius-base
 
 // Enable scrollable blocks of code
 .pre-scrollable

--- a/lib/colors/index.styl
+++ b/lib/colors/index.styl
@@ -88,7 +88,7 @@
 
 // Hue Palette
 .hue-palette
-  border-radius: $border-radius
+  border-radius: $border-radius-base
   color: #fff
   font-size: $font-size-small
   line-height: padding-vertical

--- a/lib/thumbnails/index.styl
+++ b/lib/thumbnails/index.styl
@@ -1,23 +1,3 @@
-//
-// Thumbnails
-// --------------------------------------------------
-
-//** Padding around the thumbnail image
-$thumbnail-padding ?=         4px
-//** Thumbnail background color
-$thumbnail-bg ?=              $body-bg
-//** Thumbnail border color
-$thumbnail-border ?=          #ddd
-//** Thumbnail border radius
-$thumbnail-border-radius ?=   $border-radius-base
-
-//** Custom text color for thumbnail captions
-$thumbnail-caption-color ?=   $text-color
-//** Padding around the thumbnail caption
-$thumbnail-caption-padding ?= 9px
-
-
-
 // Mixin and adjust the regular image class
 .thumbnail
   display block

--- a/lib/vars/index.styl
+++ b/lib/vars/index.styl
@@ -218,8 +218,23 @@ $dl-horizontal-breakpoint ?=  $grid-float-breakpoint
 //** Horizontal line color.
 $hr-border ?=                 $gray-lighter
 
+//
+// Thumbnails
+// --------------------------------------------------
 
+//** Padding around the thumbnail image
+$thumbnail-padding ?=         4px
+//** Thumbnail background color
+$thumbnail-bg ?=              $body-bg
+//** Thumbnail border color
+$thumbnail-border ?=          #ddd
+//** Thumbnail border radius
+$thumbnail-border-radius ?=   $border-radius-base
 
+//** Custom text color for thumbnail captions
+$thumbnail-caption-color ?=   $text-color
+//** Padding around the thumbnail caption
+$thumbnail-caption-padding ?= 9px
 
 //
 // Spacing


### PR DESCRIPTION
Close #95

Thumbnails related variables are used in the scaffolding folder so if we put them in the thumbnails folder they are undefined.
I moved thumbnail variables from thumbnails folder to variables.

Also change `$border-radius` for `$border-radius-base`