### PR TITLE
Fix bug with comment syntax.

### DIFF
--- a/lib/tables/index.styl
+++ b/lib/tables/index.styl
@@ -2,7 +2,7 @@
 // Tables
 // --------------------------------------------------
 
-//** Padding for `<th>`s and `<td>`s.
+// Padding for <th>s and <td>s.
 $table-cell-padding ?=           8px
 $table-condensed-cell-padding ?= 5px
 $table-bg ?=                     transparent


### PR DESCRIPTION
Removing character from this comment prevent stylus to create empty declaration:

```
table {
    background-color:transparent;
    font-size:14px;
    td:,
}
```