### PR TITLE
Emails templates line-height

### DIFF
--- a/lib/emails/_modules/defaults.ejs
+++ b/lib/emails/_modules/defaults.ejs
@@ -1,6 +1,6 @@
 <% // Keep one level indent %>
-  <mj-class name="subtitle" font-size="26px" color="#212121" padding="0 20px 15px 20px" margin="0" line-height="40" />
-  <mj-text align="center" color="#222228" font-family="'Avenir Next', Avenir, sans-serif" line-height="30" font-size="16px" />
+  <mj-class name="subtitle" font-size="26px" color="#212121" padding="0 20px 15px 20px" margin="0" line-height="40px" />
+  <mj-text align="center" color="#222228" font-family="'Avenir Next', Avenir, sans-serif" line-height="30px" font-size="16px" />
   <mj-list color="#222228" font-family="'Avenir Next', Avenir, sans-serif" line-height="30px" font-size="16px" />
   <mj-button font-family="'Avenir Next', Avenir, sans-serif" background-color="#EB5424" font-size="12px" color="white" font-weight="500" padding="14px 20px" />
   <mj-table font-family="'Avenir Next', Avenir, sans-serif" padding="20px"/>

--- a/lib/emails/_modules/hero.ejs
+++ b/lib/emails/_modules/hero.ejs
@@ -5,7 +5,7 @@
     <% } %>
 
     <% if (locals.title) { %>
-    <mj-text font-size="32px" line-height="60" color="white" padding="0 20px 0 20px" margin="0">
+    <mj-text font-size="32px" line-height="60ps" color="white" padding="0 20px 0 20px" margin="0">
       <%- locals.title %>
     </mj-text>
     <% } %>

--- a/lib/emails/notifications/demo.ejs
+++ b/lib/emails/notifications/demo.ejs
@@ -27,7 +27,7 @@
       </mj-section>
 
       <mj-section background-color="#222228"  padding="10px">
-        <mj-text font-size="12px" line-height="20" color="lightgray">
+        <mj-text font-size="12px" line-height="20px" color="lightgray">
           You're receiving this email because you have an <strong style="font-weight: 500;">Auth0 account</strong>. If you are not sure why you’re reciving this, please contact your systems administrator.
         </mj-text>
         <mj-spacer height="30px" />

--- a/lib/emails/product-welcome/demo.ejs
+++ b/lib/emails/product-welcome/demo.ejs
@@ -41,3 +41,4 @@
     <mj-container>
   </mj-body>
 </mjml>
+


### PR DESCRIPTION
Some line-height values was broken in the email templates. It is fixed.