### PR TITLE
Redesign and add to website the label component.

### DIFF
--- a/packages/components/src/labels/configuration.json
+++ b/packages/components/src/labels/configuration.json
@@ -1,0 +1,4 @@
+{
+  "title": "Labels",
+  "description": "<p>Labels are used to provide additional information about something.</p>"
+}

--- a/packages/components/src/labels/demo.pug
+++ b/packages/components/src/labels/demo.pug
@@ -1,0 +1,6 @@
+.label.label-default Default
+.label.label-primary Primary
+.label.label-success Success
+.label.label-info Info
+.label.label-warning Warning
+.label.label-danger Danger

--- a/packages/components/src/labels/index.styl
+++ b/packages/components/src/labels/index.styl
@@ -22,15 +22,18 @@ $label-link-hover-color ?=    #fff
 
 .label
   display inline
-  padding .2em .6em .3em
+  padding .3em 1.2em
   font-size 75%
-  font-weight bold
   line-height 1
   color $label-color
   text-align center
   white-space nowrap
   vertical-align baseline
+  border 1px solid
   border-radius .25em
+  font-weight 500
+  text-transform uppercase
+  letter-spacing 1px
 
   // Add hover effects, but only for links
   a&

--- a/packages/core/src/mixins/mixins/labels.styl
+++ b/packages/core/src/mixins/mixins/labels.styl
@@ -1,8 +1,10 @@
 // Labels
 label-variant($color)
-  background-color $color
+  color $color
+  border-color $color
 
   &[href]
     &:hover,
     &:focus
-      background-color darken($color, 10)
+      color darken($color, 10)
+      border-color darken($color, 10)

--- a/packages/website/src/html/components/Sidebar/sidebar-config.json
+++ b/packages/website/src/html/components/Sidebar/sidebar-config.json
@@ -33,6 +33,7 @@
       { "text": "Footer" },
       { "text": "Modals" },
       { "text": "Tables" },
+      { "text": "Labels" },
       { "text": "Navs" },
       { "text": "Showcase tabs" },
       { "text": "Spinner" },

--- a/packages/website/src/html/containers/Components/index.js
+++ b/packages/website/src/html/containers/Components/index.js
@@ -12,6 +12,7 @@ const componentsList = [
   'footer',
   'modals',
   'tables',
+  'labels',
   'navs',
   'showcase-tabs',
   'spinner',


### PR DESCRIPTION
Redesign of labels inherited from Bootstrap.
http://getbootstrap.com/components/#labels

![image](https://cloud.githubusercontent.com/assets/6318057/21485392/89bf1206-cb81-11e6-9ee5-7a07d10d1d56.png)


Close https://github.com/auth0/styleguide/issues/67.