### PR TITLE
Refactor notifications component to use flexbox

### DIFF
--- a/packages/components/src/notifications/demo.pug
+++ b/packages/components/src/notifications/demo.pug
@@ -1,5 +1,3 @@
-//- Here we have two kind of notifications: Global and Non Global Notifications. For change the color of any notification just add a class to container ".notification". The notification container class can be ".frendly", ".atention" and "warning".
-
 h5 Global Notifications
 
 .auth0-notification-global.primary

--- a/packages/components/src/notifications/index.styl
+++ b/packages/components/src/notifications/index.styl
@@ -51,7 +51,7 @@
 			margin-left: 0;
 
 .auth0-notification
-	padding: 25px 60px
+	padding: 25px 20px
 	box-shadow 0 2px 4px rgba(0,0,0,.11)
 	display: flex
 	align-items: center
@@ -65,12 +65,10 @@
 	padding: 0
 	
 	.container
-		padding: 25px 60px
+		padding: 25px 20px
 		width: 100%
 		display: flex
 		align-items: center
 
 		+breakpoint("tablet", "max")
 			flex-direction: column;
-			padding-left: 20px;
-			padding-right: 20px;

--- a/packages/components/src/notifications/index.styl
+++ b/packages/components/src/notifications/index.styl
@@ -2,20 +2,32 @@
 .auth0-notification-global
 	background: white
 	margin-bottom: 25px
-	position: relative
 	overflow: hidden
+	position: relative
 	
 	.notification-icon
-		line-height: 1;
-		position: absolute;
-		left: 20px;
-		top: 30px;
-		font-size: 18px;
+		line-height: 1
+		font-size: 18px
+
+		+breakpoint("tablet", "max")
+			margin-bottom: 14px
+
+		+breakpoint("tablet", "min")
+			margin-right: 25px
+
+	.btn
+		flex-shrink: 0
+
+		+breakpoint("tablet", "min")
+			margin-left: 25px
 	
 	p
-		margin: 0 0
-		float: left
-		width: 80%
+		margin: 0
+		flex-grow: 1
+
+		+breakpoint("tablet", "max")
+			margin-bottom: 14px;
+			text-align: center;
 	
 	&.primary .notification-icon
 		color: #44C7F4
@@ -28,21 +40,24 @@
 	
 	.close
 		color: #ddd
-		position: absolute
-		top: 30px
-		right: 15px
 		font-size: 14px;
 		opacity: 1
-		
-	.btn
-		position:absolute
-		right: 15px
-		top: 19px
-		max-width: 20%
+		margin-left: 25px;
+
+		+breakpoint("tablet", "max")
+			position: absolute;
+			top: 15px;
+			right: 15px;
+			margin-left: 0;
 
 .auth0-notification
 	padding: 25px 60px
 	box-shadow 0 2px 4px rgba(0,0,0,.11)
+	display: flex
+	align-items: center
+
+	+breakpoint("tablet", "max")
+		flex-direction: column;
 
 .auth0-notification-global
 	background: transparent
@@ -52,4 +67,10 @@
 	.container
 		padding: 25px 60px
 		width: 100%
-		position: relative
+		display: flex
+		align-items: center
+
+		+breakpoint("tablet", "max")
+			flex-direction: column;
+			padding-left: 20px;
+			padding-right: 20px;


### PR DESCRIPTION
- Replace position absolute by flexbox
- Add responsive styles

Should fix error with `width: 80%` declaration in component paragraphs that prevented text section to take all the remaining space.
![image](https://user-images.githubusercontent.com/6318057/30336273-0c93435e-97bb-11e7-9e49-66793772c023)


### Responsive:

![image](https://user-images.githubusercontent.com/6318057/30336336-418cc260-97bb-11e7-8db2-c03eee373b54.png)

![image](https://user-images.githubusercontent.com/6318057/30336345-4709696e-97bb-11e7-9869-44f7f5da8f39.png)


