### PR TITLE
Corrected brand-success color

### DIFF
--- a/packages/core/src/vars/colors.styl
+++ b/packages/core/src/vars/colors.styl
@@ -10,7 +10,7 @@ $gray-light ?=          lighten($gray-base, 46.7) // #777
 $gray-lighter ?=        lighten($gray-base, 93.5) // #eee
 
 $brand-primary ?=       #44c7f4
-$brand-success ?=       #eb5424
+$brand-success ?=       #7ed321
 $brand-info ?=          #5bc0de
 $brand-warning ?=       #f0ad4e
 $brand-danger ?=        #d9534f


### PR DESCRIPTION
Changed color from #eb5424 to #7ed321, which matches $bg-color-success. Fixes #189 