### PR TITLE
Corrected links

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,4 +42,4 @@ For more information on how to run each package check the specific README.
 
 All the logos and branding are copyright Auth0 and may not be used or reproduced without explicit permission from Auth0 Inc.
 
-The icons are licensed from [Budi Harto Tanrim](http://budicon.buditanrim.co/). All other third-party components are subject to their own licenses.
+The icons are licensed from [Budi Harto Tanrim](https://budicon.co/). All other third-party components are subject to their own licenses.

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -44,4 +44,4 @@ bin/version patch
 
 All the logos and branding are copyright Auth0 and may not be used or reproduced without explicit permission from Auth0 Inc.
 
-The icons are licensed from [Budi Harto Tanrim](http://budicon.buditanrim.co/). All other third-party components are subject to their own licenses.
+The icons are licensed from [Budi Harto Tanrim](https://budicon.co/). All other third-party components are subject to their own licenses.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -44,4 +44,4 @@ bin/version patch
 
 All the logos and branding are copyright Auth0 and may not be used or reproduced without explicit permission from Auth0 Inc.
 
-The icons are licensed from [Budi Harto Tanrim](http://budicon.buditanrim.co/). All other third-party components are subject to their own licenses.
+The icons are licensed from [Budi Harto Tanrim](https://budicon.co/). All other third-party components are subject to their own licenses.

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -160,4 +160,4 @@ bin/version patch
 
 All the logos and branding are copyright Auth0 and may not be used or reproduced without explicit permission from Auth0 Inc.
 
-The icons are licensed from [Budi Harto Tanrim](http://budicon.buditanrim.co/). All other third-party components are subject to their own licenses.
+The icons are licensed from [Budi Harto Tanrim](https://budicon.co/). All other third-party components are subject to their own licenses.

--- a/packages/website/src/html/containers/Resources/index.js
+++ b/packages/website/src/html/containers/Resources/index.js
@@ -126,8 +126,7 @@ class Resources extends Component {
             <h2 id="icons">Icons</h2>
             <p>
               Iconography is another language to communicate visually. Built by
-              &nbsp;
-              <a href="http://budicon.buditanrim.co/preview">Budi</a>.
+              <a href="https://budicon.co/">Budi</a>.
             </p>
             <input
               className="form-control"


### PR DESCRIPTION
### Description

The links were redirecting and taking some time to do it, so I replaced them with the new link to cut out the redirect. The link in index.js was dead entirely, so I also replaced it with the closest thing at the new URL.

### Testing

Was not tested. README changes do not need testing, but I removed an `&nbsp;` from index.js because on the website the text was displayed with two spaces in front of it. You can view this behaviot [here](https://styleguide.auth0.com/resources/icons#icons). I'm assuming removing this space resolves the issue.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
