### PR TITLE
Uploaded svg to website cdn folder

### DIFF
--- a/packages/components/src/circle-logo/index.styl
+++ b/packages/components/src/circle-logo/index.styl
@@ -469,6 +469,6 @@ rel_width = 8em;
       background: linear-gradient(-220deg, #f3f3f3 23%, #CECCBB 100%);
 
       &:after
-        background-image: url('https://cdn.auth0.com/styleguide/components/2.0.11/media/circle-logo/img/nextjs.svg');
+        background-image: url('https://cdn.auth0.com/website/styleguide/components/2.0.11/media/circle-logo/img/nextjs.svg');
         width: 80%;
         height: 80%;


### PR DESCRIPTION
Styleguide is no longer published

Hosted img:
![img](https://cdn.auth0.com/website/styleguide/components/2.0.11/media/circle-logo/img/nextjs.svg)