### PR TITLE
fix: use lint:js in test script

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -12,7 +12,7 @@
     "lint": "npm run lint:js && npm run lint:css",
     "lint:js": "eslint .",
     "lint:css": "stylelint build/components.css",
-    "test": "npm run lint"
+    "test": "npm run lint:js"
   },
   "keywords": [
     "auth0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,7 +12,7 @@
     "lint": "npm run lint:js && npm run lint:css",
     "lint:js": "eslint .",
     "lint:css": "stylelint build/core.css",
-    "test": "npm run lint"
+    "test": "npm run lint:js"
   },
   "keywords": [
     "auth0",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -19,7 +19,7 @@
     "lint": "npm run lint:js && npm run lint:css",
     "lint:js": "eslint .",
     "lint:css": "stylelint build/react-components.css",
-    "test": "npm run lint && mocha \"src/**/*.test.js\" --require test/setup.js --compilers js:babel-register"
+    "test": "npm run lint:js && mocha \"src/**/*.test.js\" --require test/setup.js --compilers js:babel-register"
   },
   "keywords": [
     "auth0",


### PR DESCRIPTION
## Summary

- Changed test script in all 3 packages to run lint:js directly instead of lint
- This fixes the race condition where Jenkins runs test and build in parallel, but lint:css requires build artifacts that don't exist yet